### PR TITLE
feat: accessToken 만료시간 변경

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: [process.env.HOSTNAME],
+    domains: [process.env.BACK_HOSTNAME],
   },
   async redirects() {
     return [

--- a/pages/api/members/me.ts
+++ b/pages/api/members/me.ts
@@ -12,7 +12,7 @@ const handleMe = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const response = await axios.get(`${BACK_URL}/api/members/me`, {
       headers: {
-        Authorization: accessToken,
+        Authorization: `Bearer ${accessToken}`,
       },
     });
     res.status(response.status).json({ ...response.data });

--- a/pages/api/signin.ts
+++ b/pages/api/signin.ts
@@ -3,7 +3,7 @@ import { serialize } from "cookie";
 import { NextApiRequest, NextApiResponse } from "next";
 
 const handleSignIn = async (req: NextApiRequest, res: NextApiResponse) => {
-  const { BACK_URL } = process.env;
+  const { BACK_URL, ACCESSTOKEN_MAX_AGE } = process.env;
 
   if (req.method !== "POST") {
     res.status(405).end();
@@ -25,10 +25,10 @@ const handleSignIn = async (req: NextApiRequest, res: NextApiResponse) => {
     res
       .setHeader(
         "Set-Cookie",
-        serialize("accessToken", `Bearer ${token}`, {
+        serialize("accessToken", token, {
           path: "/",
           httpOnly: true,
-          maxAge: 60 * 60 * 24 * 7,
+          maxAge: ACCESSTOKEN_MAX_AGE ? +ACCESSTOKEN_MAX_AGE : 86400,
         })
       )
       .status(response.status)

--- a/pages/api/signout.ts
+++ b/pages/api/signout.ts
@@ -6,7 +6,6 @@ const handleSignOut = async (req: NextApiRequest, res: NextApiResponse) => {
     res.status(405).end();
     return;
   }
-  console.log("handleSignOut");
   res
     .setHeader(
       "Set-Cookie",

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -10,7 +10,6 @@ const handleSignUp = async (req: NextApiRequest, res: NextApiResponse) => {
     return;
   }
   const { email, password, nickname, profileImage } = req.body;
-  console.log(email, password, nickname, profileImage);
   const formData = new FormData();
   formData.append("email", email);
   formData.append("password", password);
@@ -30,7 +29,6 @@ const handleSignUp = async (req: NextApiRequest, res: NextApiResponse) => {
     res.status(response.status).json({ ...response.data });
   } catch (error) {
     const axiosError = error as AxiosError;
-    console.log("response status", axiosError.response?.status);
     res
       .status(axiosError.response?.status || 500)
       .json({ ...axiosError.response?.data });

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -46,7 +46,7 @@ const SignInPage: NextPageWithLayout = () => {
     [email, password, dispatch, signin]
   );
 
-  if (signinState.signinLoading || user.accessToken) {
+  if (signinState.signinLoading) {
     return <div>로딩중...</div>;
   }
 


### PR DESCRIPTION
accessToken 만료시간 7일에서 1일로 변경(서버에서 1일로 세팅된 토큰 넘겨줌).
cookie에 'Bearer token'으로 저장했었는데 token만 저장하는 것으로 변경.
그래서 members/me 요청할 때 Authrization값에 Bearer 추가함.

close #35 